### PR TITLE
Support for Computed value in annotated feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ struct UserFlags: FlagCollectionProtocol {
     
     @Flag(key: "rating_mode", default: "at_launch", description: "The behaviour to show the rating popup")
     var appReviewRating: String
+
+    public init() {}
 }
 ```
 
@@ -109,9 +111,11 @@ The following documentation describe detailed usage of the library.
 - 1.0 - [Introduction](./documentation/introduction.md)  
     - 1.1 - [@Flag Annotation](./documentation/introduction.md#11-flag-annotation)
     - 1.2 - [@Flag Supported Datatypes](./documentation/introduction.md#12--flag-supported-data-types)
-    - 1.3 - [Load a Feature Flag Collection in a `FlagLoader`](./documentation/introduction.md#13-load-a-feature-flag-collection-in-a-flagloader)
-    - 1.4 - [Configure Key Evaluation for `FlagsLoader`'s `@Flag`](./documentation/introduction.md#14-configure-key-evaluation-for-flagsloaders-flag)
-    - 1.5 - [Query a specific data provider](./documentation/introduction.md#15-query-a-specific-data-provider)
+    - 1.3 - [`Codable` types and `@Flag`](#13-codable-types-and--flag)
+    - 1.4 - [Computed @Flag](./documentation/introduction.md#14-computed--flag)
+    - 1.5 - [Load a Feature Flag Collection in a `FlagLoader`](./documentation/introduction.md#15-load-a-feature-flag-collection-in-a-flagloader)
+    - 1.6 - [Configure Key Evaluation for `FlagsLoader`'s `@Flag`](./documentation/introduction.md#16-configure-key-evaluation-for-flagsloaders-flag)
+    - 1.7 - [Query a specific data provider](./documentation/introduction.md#17-query-a-specific-data-provider)  
 - 2.0 - [Organize Feature Flags](./documentation/organize_feature_flags.md)  
     - 2.1 - [The `@FlagCollection` annotation](./documentation/organize_feature_flags.md#21-the-flagcollection-annotation)
     - 2.2 - [Nested Structures](./documentation/organize_feature_flags.md#22-nested-structures)

--- a/RealFlags/Sources/RealFlags/Classes/Flag/FlagProtocol/Supported Encoded Types/FlagProtocol+Foundation.swift
+++ b/RealFlags/Sources/RealFlags/Classes/Flag/FlagProtocol/Supported Encoded Types/FlagProtocol+Foundation.swift
@@ -14,7 +14,7 @@ import Foundation
 
 // MARK: - Codable
 
-extension Decodable where Self: FlagProtocol, Self: Encodable {
+public extension Decodable where Self: FlagProtocol, Self: Encodable {
     
     public init?(encoded value: EncodedFlagValue) {
         guard case .data(let data) = value else {
@@ -31,7 +31,7 @@ extension Decodable where Self: FlagProtocol, Self: Encodable {
     
 }
 
-extension Encodable where Self: FlagProtocol, Self: Decodable {
+public extension Encodable where Self: FlagProtocol, Self: Decodable {
     
     public func encoded() -> EncodedFlagValue {
         do {

--- a/RealFlagsFirebase.podspec
+++ b/RealFlagsFirebase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RealFlagsFirebase"
-  s.version      = "1.0.1"
+  s.version      = "1.1.0"
   s.summary      = "Feature flagging framework for Swift: FirebaseRemoteConfig Data Provider"
   s.homepage     = "https://github.com/immobiliare/RealFlags.git"
   s.license      = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
This PR add support for computed value for annotated `@Flag` properties.  
This feature allows you to define a closure function which may return a custom value for an annotated flag.  
If value returned from callback is not `nil` this is the value of the flag and no other checks are made.  
If the value returned is `nil` the flow continues by asking to any provider specified (in order) and eventually returning the fallback return value.

This is an example:  
Suppose you have a feature flag called `hasPublishButton`: it should return true only when the app's language is set to `it`. 
This is how we should define this behaviour:

```swift
public struct MiscFlags: FlagCollectionProtocol {

    // MARK: - Flags

    @Flag(default: false, computedValue: MiscFlags.computedPublishButton, description: "")
    var hasPublishButton: Bool
            
    // MARK: - Computed Properties Functions

    public init() { }

    private static func computedPublishButton() -> Bool? {
        Language.main.code == "it"
    }
}
```