### PR TITLE
Define resources explicitly

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,11 @@ let package = Package(
         .target(
             name: "RealFlags",
             dependencies: [],
-            path: "RealFlags/Sources"
+            path: "RealFlags/Sources",
+            resources: [
+                .process("RealFlags/Classes/Browser/*.storyboard"),
+                .process("RealFlags/Classes/Browser/Cells/*.xib")
+            ]
         ),
         .target(
             name: "RealFlagsFirebase",


### PR DESCRIPTION
I generated a Xcode project from the Swift Package and imported the generated Xcode into my workspace.

I get the following error when compiling my workspace

<img width="999" alt="Screenshot 2022-04-10 at 3 19 56 PM" src="https://user-images.githubusercontent.com/478757/162607236-b8a8a77b-446f-4f3d-bab6-5ae8b863c871.png">

My main use case is to be able to use this library together with tuist. The discussion about this use case is [here](https://github.com/tuist/tuist/discussions/4352)